### PR TITLE
Update index.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,7 +176,7 @@ class MqttClient {
 
       const opts: ConnectionOptions = Object.assign(
         {},
-        { ...options, clientId: 'clientId' }
+        { clientId: 'clientId', ...options }
       );
       if (opts.tls && opts.tls.p12) {
         opts.tls = Object.assign({}, opts.tls);


### PR DESCRIPTION
Client id was hardcoded to "ClientId" on every connection which on mosquitto server cause a disconect when multiple devices try to connect to the server. 

I change the order how ConnectionOptions are merged to prioritise the custom ClientId set outside the library.